### PR TITLE
Add missing python3-ropgadget

### DIFF
--- a/build.bash
+++ b/build.bash
@@ -81,6 +81,9 @@ check_and_install curl
 # Check and install python3
 check_and_install python3
 
+# Check and install ROPgadget
+check_and_install python3-ropgadget
+
 # Install pip for Python3
 install_pip
 


### PR DESCRIPTION
Just the one line needed to install python3-ropgadget, needed for ROPgadget.